### PR TITLE
fix: Prevent matrix include error

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,5 +73,5 @@ var rootModules = flattenEntries(ciFileEntries)
 
 rootModules = filterRootModules(rootModules);
 
-const includeStatement = { include: rootModules };
+const includeStatement = rootModules.length === 0 ? {} : { include: rootModules };
 core.setOutput("matrix", includeStatement);


### PR DESCRIPTION
Getting this error in our CI and CD pipelines, which is more of a warning:
```
CI Pipeline: .github#L1Error when evaluating 'strategy' for job 'run-tf-jobs'. .github/workflows/pull-request.yaml (Line: 44, Col: 15): Matrix must define at least one vector
--

[CI Pipeline: .github#L1](https://github.com/algodx-ab/infrastructure/pull/1460/files#annotation_11514943093)
Error when evaluating 'strategy' for job 'run-tf-jobs'. .github/workflows/pull-request.yaml (Line: 44, Col: 15): Matrix must define at least one vector
```